### PR TITLE
Word choice and grammar in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ cycle-react is immutable and uses
 [PureRenderMixin](https://facebook.github.io/react/docs/pure-render-mixin.html)
 internally by default.
 
-On the other hand, cycle-react is a React-style implementation of a beautiful
+Additionally, cycle-react is also a React-style implementation of a beautiful
 framework called [Cycle.js](https://github.com/staltz/cycle).
 
 ## Installing


### PR DESCRIPTION
"On the other hand" isn't the correct word choice here (I think). If the intention is to inform the reader that `cycle-react` fufills another purpose besides being a stand-alone functional interface for React this new wording is better.
